### PR TITLE
[feature/#1] [홈탭] 안드로이드 아이콘 노출 개선

### DIFF
--- a/features/home/src/main/res/layout/item_info_header.xml
+++ b/features/home/src/main/res/layout/item_info_header.xml
@@ -49,7 +49,7 @@
                 android:layout_height="36dp"
                 app:layout_constraintStart_toStartOf="@id/leftGuide"
                 app:layout_constraintTop_toTopOf="parent"
-                app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.DifferentCornerSize.8dp"
+                app:shapeAppearanceOverlay="@style/RoundedHeaderLogo"
                 app:srcCompat="@drawable/ic_android_white" />
 
             <TextView

--- a/features/home/src/main/res/layout/item_info_header.xml
+++ b/features/home/src/main/res/layout/item_info_header.xml
@@ -43,14 +43,14 @@
                 android:orientation="vertical"
                 app:layout_constraintGuide_end="16dp" />
 
-            <!-- TODO : Radius 8dp로 ImageView 노출 -->
-            <ImageView
+            <com.google.android.material.imageview.ShapeableImageView
                 android:id="@+id/logo"
                 android:layout_width="36dp"
                 android:layout_height="36dp"
-                android:src="@drawable/ic_android_white"
                 app:layout_constraintStart_toStartOf="@id/leftGuide"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.DifferentCornerSize.8dp"
+                app:srcCompat="@drawable/ic_android_white" />
 
             <TextView
                 android:id="@+id/tvDroidKnights"

--- a/features/home/src/main/res/values/styles.xml
+++ b/features/home/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="ShapeAppearanceOverlay.DifferentCornerSize.8dp">
+    <style name="RoundedHeaderLogo">
         <item name="cornerSizeTopRight">8dp</item>
         <item name="cornerSizeTopLeft">8dp</item>
         <item name="cornerSizeBottomLeft">8dp</item>

--- a/features/home/src/main/res/values/styles.xml
+++ b/features/home/src/main/res/values/styles.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="ShapeAppearanceOverlay.DifferentCornerSize.8dp">
+        <item name="cornerSizeTopRight">8dp</item>
+        <item name="cornerSizeTopLeft">8dp</item>
+        <item name="cornerSizeBottomLeft">8dp</item>
+        <item name="cornerSizeBottomRight">8dp</item>
+        <item name="cornerFamily">rounded</item>
+    </style>
+</resources>


### PR DESCRIPTION
## Issue
- close #1 

## Overview (Required)
- ImageView를 Material ShapeableImageView로 변환
- app:shapeAppearanceOverlay attribute에 corner 속성을 적용

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/1534926/126504913-745e8e66-781f-4327-b57b-3a56ed5f1875.png" width="300" /> | <img src="https://user-images.githubusercontent.com/54518925/128588745-2f0f75df-c838-4aab-af39-b75944c2fee3.jpeg" width="300" />
