### PR TITLE
[feature/#3] [홈탭] 올해 행사 일자 문구 노출 수정

### DIFF
--- a/features/home/src/main/java/com/droidknights/app2021/home/databinding/adapters/ViewBindingadapter.kt
+++ b/features/home/src/main/java/com/droidknights/app2021/home/databinding/adapters/ViewBindingadapter.kt
@@ -23,12 +23,7 @@ fun TextView.bindEventTitle(date: LocalDate) {
     text = "${date.year}년 드로이드 나이츠"
 }
 
-@BindingAdapter("bindEventDate", "bindEndEvent")
-fun TextView.bindEventDate(date: LocalDate, isEndEvent: Boolean) {
-    // TODO: 종료되지 않은 이벤트 노출 개선
-    text = if (isEndEvent) {
-        "${date.year}년 ${date.monthNumber}월 ${date.dayOfMonth}일"
-    } else {
-        "${date.year}년 ${date.monthNumber}월 예정"
-    }
+@BindingAdapter("bindEventDate")
+fun TextView.bindEventDate(date: LocalDate) {
+    text = "${date.year}년 ${date.monthNumber}월 ${date.dayOfMonth}일"
 }

--- a/features/home/src/main/res/layout/item_event.xml
+++ b/features/home/src/main/res/layout/item_event.xml
@@ -59,7 +59,6 @@
             android:textColor="#9A9A9A"
             android:textSize="14sp"
             android:textStyle="bold"
-            app:bindEndEvent="@{item.endEvent}"
             app:bindEventDate="@{item.date}"
             app:layout_constrainedWidth="true"
             app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
## Issue
- close #3 

## Overview (Required)
- TextView에 Date만 뜰 수 있도록 BindingAdapter 변경
- 이때, isEndEvent는 사용되지 않아 parameter 삭제

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/1534926/126509012-ad8808f4-a1c0-4278-bc55-4615a5f78ab6.png" width="300" /> | <img src="https://user-images.githubusercontent.com/54518925/128589876-31d21bce-43fb-43fc-bfed-9690fe485aae.jpeg" width="300" />
