### PR TITLE
(#7) [스케쥴] 세션 노출 순서 개선

### DIFF
--- a/domain/src/main/java/com/droidknights/app2021/domain/usecase/session/GetSessionsUseCase.kt
+++ b/domain/src/main/java/com/droidknights/app2021/domain/usecase/session/GetSessionsUseCase.kt
@@ -26,6 +26,5 @@ class GetSessionsUseCase @Inject constructor(
                 )
             }
             .sortedWith(compareBy({ it.startTime }, { it.title }))
-            .sortedBy { it.room }
     }
 }

--- a/domain/src/main/java/com/droidknights/app2021/domain/usecase/session/GetSessionsUseCase.kt
+++ b/domain/src/main/java/com/droidknights/app2021/domain/usecase/session/GetSessionsUseCase.kt
@@ -25,6 +25,7 @@ class GetSessionsUseCase @Inject constructor(
                     endTime = it.endTime
                 )
             }
-        // TODO: 시간, 세션명 순으로 정렬
+            .sortedWith(compareBy({ it.startTime }, { it.title }))
+            .sortedBy { it.room }
     }
 }


### PR DESCRIPTION
## Issue
- close #7 

## Overview (Required)
- json파일에서 `startTime`과 `title`을 기준으로 정렬했습니다.

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/57510192/128730121-ec061181-2db2-4f78-b234-d4ef1559bdaf.PNG" width="300" /> | <img src="https://user-images.githubusercontent.com/57510192/128729707-115b0aaa-6a6d-44df-a342-af7b4fb4f78a.PNG" width="300" />
<img src="https://user-images.githubusercontent.com/57510192/128729667-6513896f-9d46-4500-81e6-39f274733215.PNG" width="300" /> | <img src="https://user-images.githubusercontent.com/57510192/128729713-c14cc1db-8177-4872-ad7b-9977dc6632f1.PNG" width="300" />