### PR TITLE
[홈탭] 이벤트간의 Divider 노출

### DIFF
--- a/features/home/src/main/java/com/droidknights/app2021/home/ui/EventItemDecoration.kt
+++ b/features/home/src/main/java/com/droidknights/app2021/home/ui/EventItemDecoration.kt
@@ -1,0 +1,47 @@
+package com.droidknights.app2021.home.ui
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Rect
+import android.graphics.drawable.Drawable
+import androidx.core.content.ContextCompat
+import androidx.core.view.children
+import androidx.recyclerview.widget.RecyclerView
+import com.droidknights.app2021.home.R
+import kotlin.math.roundToInt
+
+class EventItemDecoration(context: Context) : RecyclerView.ItemDecoration() {
+
+    private val itemViewType: Int = R.layout.item_event
+
+    private val divider: Drawable =
+        ContextCompat.getDrawable(context, R.drawable.event_list_divider)!!
+
+    private val horizontalMargin: Int =
+        context.resources.getDimensionPixelSize(R.dimen.event_list_divider_margin)
+
+    private val bounds = Rect()
+
+    override fun onDraw(c: Canvas, parent: RecyclerView, state: RecyclerView.State) {
+        if (parent.layoutManager == null) {
+            return
+        }
+        c.save()
+        val left = horizontalMargin
+        val right = parent.width - horizontalMargin
+        var previousViewType: Int? = null
+        parent.children.forEach { child ->
+            val adapterPosition = parent.getChildAdapterPosition(child)
+            val viewType = parent.adapter?.getItemViewType(adapterPosition)
+            if (viewType == itemViewType && previousViewType == viewType) {
+                parent.getDecoratedBoundsWithMargins(child, bounds)
+                val top: Int = bounds.top + child.translationY.roundToInt()
+                val bottom: Int = top + divider.intrinsicHeight
+                divider.setBounds(left, top, right, bottom)
+                divider.draw(c)
+            }
+            previousViewType = viewType
+        }
+        c.restore()
+    }
+}

--- a/features/home/src/main/java/com/droidknights/app2021/home/ui/HomeFragment.kt
+++ b/features/home/src/main/java/com/droidknights/app2021/home/ui/HomeFragment.kt
@@ -1,13 +1,16 @@
 package com.droidknights.app2021.home.ui
 
+import android.graphics.drawable.GradientDrawable
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.ConcatAdapter
+import androidx.recyclerview.widget.DividerItemDecoration
 import com.droidknights.app2021.core.ui.ActivityHelper
 import com.droidknights.app2021.home.R
 import com.droidknights.app2021.home.databinding.FragmentHomeBinding
@@ -37,6 +40,7 @@ class HomeFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         viewModel.homeInfo.observe(viewLifecycleOwner) {
             val concatAdapter = ConcatAdapter(
+                ConcatAdapter.Config.Builder().setIsolateViewTypes(false).build(),
                 HeaderAdapter(),
                 InfoAdapter(it.sponsors, object : InfoAdapter.ItemHandler {
                     override fun clickSponsor(sponsor: Sponsor) {
@@ -52,8 +56,7 @@ class HomeFragment : Fragment() {
                 })
             )
             binding.recyclerView.adapter = concatAdapter
-
-            // TODO: 이벤트 항목간의 Divider 추가
+            binding.recyclerView.addItemDecoration(EventItemDecoration(view.context))
         }
     }
 }

--- a/features/home/src/main/res/drawable/event_list_divider.xml
+++ b/features/home/src/main/res/drawable/event_list_divider.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#F1F1F1" />
+    <size
+        android:width="1dp"
+        android:height="1dp" />
+</shape>

--- a/features/home/src/main/res/values/dimens.xml
+++ b/features/home/src/main/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="event_list_divider_margin">16dp</dimen>
+</resources>


### PR DESCRIPTION
## Issue
- close #5

## Overview (Required)
- 홈탭 내의 이벤트 간 divider 추가합니다. (=`EventItemDecoration`)
- ItemDecoration으로 구현하는 것을 의도한 것으로 보여서,
   ItemViewType을 확인할 수 있게 ConcatAdapter를 `isolateViewTypes` false로 설정했습니다.
- 디자인가이드에 맞는 리소스 추가했습니다.

## Links
- 참고: [androidx/recyclerview/widget/DividerItemDecoration.java](https://github.com/androidx/androidx/blob/androidx-main/recyclerview/recyclerview/src/main/java/androidx/recyclerview/widget/DividerItemDecoration.java)

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/3405740/128636885-4f529d79-dc3a-49e2-9228-007abcdd6e1c.png" width="300" /> | <img src="https://user-images.githubusercontent.com/3405740/128636882-4e6e43b8-f5ef-489a-857c-13432090bb4d.png" width="300" />
