### PR TITLE
(#8) [KSerializer] json을 DTO로 만들때의 Room Enum 직렬화 개선

### DIFF
--- a/data/src/main/java/com/droidknights/app2021/data/model/SessionData.kt
+++ b/data/src/main/java/com/droidknights/app2021/data/model/SessionData.kt
@@ -19,8 +19,6 @@ data class SessionData(
     val speakers: List<User>,
     val level: Level,
     val tags: List<Tag> = emptyList(),
-    // TODO: Track1, track1은 Room.Track1으로 매칭되어야한다.
-    // TODO: 트랙정보가 올바르게 매칭되지 않을시 Room.Etc로 매칭되어야한다
     val room: Room = Room.Etc,
     val startTime: LocalDateTime,
     val endTime: LocalDateTime,

--- a/shared/src/main/java/com/droidknights/app2021/shared/Domain.kt
+++ b/shared/src/main/java/com/droidknights/app2021/shared/Domain.kt
@@ -1,5 +1,6 @@
 package com.droidknights.app2021.shared
 
+import com.droidknights.app2021.shared.serializable.RoomAsStringSerializer
 import kotlinx.serialization.Serializable
 
 @JvmInline
@@ -17,6 +18,7 @@ value class Level(val name: String)
 @JvmInline
 value class Tag(val name: String)
 
+@Serializable(RoomAsStringSerializer::class)
 enum class Room {
     Track1,
     Track2,

--- a/shared/src/main/java/com/droidknights/app2021/shared/serializable/RoomAsStringSerializer.kt
+++ b/shared/src/main/java/com/droidknights/app2021/shared/serializable/RoomAsStringSerializer.kt
@@ -1,0 +1,23 @@
+package com.droidknights.app2021.shared.serializable
+
+import com.droidknights.app2021.shared.Room
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+class RoomAsStringSerializer: KSerializer<Room> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor(javaClass.name, PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: Room) {
+        encoder.encodeString(value.name)
+    }
+
+    override fun deserialize(decoder: Decoder): Room {
+        return try {
+            Room.valueOf(decoder.decodeString().replaceFirstChar { it.uppercaseChar() })
+        } catch (e: IllegalArgumentException) {
+            Room.Etc
+        }
+    }
+}

--- a/shared/src/main/java/com/droidknights/app2021/shared/serializable/RoomAsStringSerializer.kt
+++ b/shared/src/main/java/com/droidknights/app2021/shared/serializable/RoomAsStringSerializer.kt
@@ -14,10 +14,7 @@ class RoomAsStringSerializer: KSerializer<Room> {
     }
 
     override fun deserialize(decoder: Decoder): Room {
-        return try {
-            Room.valueOf(decoder.decodeString().replaceFirstChar { it.uppercaseChar() })
-        } catch (e: IllegalArgumentException) {
-            Room.Etc
-        }
+        val decodedString = decoder.decodeString()
+        return Room.values().find { it.name.lowercase() == decodedString.lowercase() } ?: Room.Etc
     }
 }


### PR DESCRIPTION
## Issue
- close #8 

## Overview (Required)
- sessions.json 내에 String으로 저장되어 있던 트랙정보를 앞 글자 대소문자 구분 없이 변환되도록 개선했습니다. (ex. Track1, track1 모두 Enum.Track1으로 변환)
- 위 규칙에 포함되지 않거나 정의되지 않은 트랙정보일 경우 Enum.Etc로 변환되도록 정의했습니다.