### PR TITLE
Repository 설정 변경

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 buildscript {
     repositories {
-        gradlePluginPortal()
         google()
         mavenCentral()
     }


### PR DESCRIPTION
## Issue
- close #30

## Overview (Required)
- `gradlePluginPortal`은 plugin block에서 내려받을 플러그인에 위한
repository이며, 앱의 빌드 또는 의존성에 필요한 라이브러리는
포함하고 있지 않습니다.
또한 라이브러리를 찾을 때마다 불필요하게 해당 repository에서 검색하게
됩니다.

 따라서 `gradlePluginPortal`은 buildscript block에서 제거해야 합니다.

## Test
```
$ ./gradlew -g $PWD/.gradle-test :app:assembleDebug
```