### PR TITLE
사용하지 않는 Qualifier Annotation 제거 

### DIFF
--- a/shared/src/main/java/com/droidknights/app2021/shared/di/CoroutinesQualifiers.kt
+++ b/shared/src/main/java/com/droidknights/app2021/shared/di/CoroutinesQualifiers.kt
@@ -17,7 +17,3 @@ annotation class MainDispatcher
 @Retention(AnnotationRetention.BINARY)
 @Qualifier
 annotation class MainImmediateDispatcher
-
-@Retention(AnnotationRetention.BINARY)
-@Qualifier
-annotation class ApplicationScope


### PR DESCRIPTION
## Issue
- close #20

## Overview (Required)
- 프로젝트 내부에 Qualifier로 추가한 ApplicationScope Annotation이 사용되고 있지 않아 제거합니다. 

