### PR TITLE
Hilt 주입 대상과 Module에 대해 internal 접근자 선언을 통해 은닉화 처리

### DIFF
--- a/app/src/main/java/com/droidknights/app2021/di/AssetModule.kt
+++ b/app/src/main/java/com/droidknights/app2021/di/AssetModule.kt
@@ -9,7 +9,7 @@ import dagger.hilt.components.SingletonComponent
 
 @InstallIn(SingletonComponent::class)
 @Module
-abstract class AssetModule {
+internal abstract class AssetModule {
     @Binds
     abstract fun bindsAssetProvider(
         assetLoader: CacheAssetLoader

--- a/app/src/main/java/com/droidknights/app2021/di/CoroutinesModule.kt
+++ b/app/src/main/java/com/droidknights/app2021/di/CoroutinesModule.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.Dispatchers
 
 @InstallIn(SingletonComponent::class)
 @Module
-object CoroutinesModule {
+internal object CoroutinesModule {
     @DefaultDispatcher
     @Provides
     fun providesDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default

--- a/app/src/main/java/com/droidknights/app2021/provider/CacheAssetLoader.kt
+++ b/app/src/main/java/com/droidknights/app2021/provider/CacheAssetLoader.kt
@@ -7,7 +7,7 @@ import com.droidknights.app2021.util.AssetUtil
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
-class CacheAssetLoader @Inject constructor(
+internal class CacheAssetLoader @Inject constructor(
     @ApplicationContext private val context: Context
 ) : AssetProvider {
     override suspend fun getRawSessions(): JsonRawString {

--- a/data/src/main/java/com/droidknights/app2021/data/di/DataModule.kt
+++ b/data/src/main/java/com/droidknights/app2021/data/di/DataModule.kt
@@ -19,7 +19,7 @@ import javax.inject.Singleton
 
 @InstallIn(SingletonComponent::class)
 @Module(includes = [DataModule.ApiModule::class])
-abstract class DataModule {
+internal abstract class DataModule {
     @Binds
     abstract fun bindsConferenceRepository(
         repository: ConferenceRepositoryImpl

--- a/data/src/main/java/com/droidknights/app2021/data/di/NetworkModule.kt
+++ b/data/src/main/java/com/droidknights/app2021/data/di/NetworkModule.kt
@@ -12,7 +12,7 @@ import javax.inject.Singleton
 
 @InstallIn(SingletonComponent::class)
 @Module
-object NetworkModule {
+internal object NetworkModule {
     @Provides
     @Singleton
     fun provideOkHttpClient(): OkHttpClient =

--- a/data/src/main/java/com/droidknights/app2021/data/repository/ConferenceRepositoryImpl.kt
+++ b/data/src/main/java/com/droidknights/app2021/data/repository/ConferenceRepositoryImpl.kt
@@ -10,7 +10,7 @@ import com.droidknights.app2021.shared.model.Sponsor
 import com.droidknights.app2021.shared.model.User
 import javax.inject.Inject
 
-class ConferenceRepositoryImpl @Inject constructor(
+internal class ConferenceRepositoryImpl @Inject constructor(
     private val conferenceApi: ConferenceApi,
     private val githubApi: GithubApi,
     private val localCacheProvider: LocalCacheProvider

--- a/features/detail/src/main/java/com/droidknights/app2021/detail/di/NavigatorModule.kt
+++ b/features/detail/src/main/java/com/droidknights/app2021/detail/di/NavigatorModule.kt
@@ -9,7 +9,7 @@ import dagger.hilt.components.SingletonComponent
 
 @InstallIn(SingletonComponent::class)
 @Module
-abstract class NavigatorModule {
+internal abstract class NavigatorModule {
     @Binds
     abstract fun provideWeeklyNavigator(
         navigator: DetailNavigatorImpl

--- a/features/detail/src/main/java/com/droidknights/app2021/detail/navigation/DetailNavigatorImpl.kt
+++ b/features/detail/src/main/java/com/droidknights/app2021/detail/navigation/DetailNavigatorImpl.kt
@@ -6,7 +6,7 @@ import com.droidknights.app2021.navigator.DetailNavigator
 import com.droidknights.app2021.shared.model.Session
 import javax.inject.Inject
 
-class DetailNavigatorImpl @Inject constructor() : DetailNavigator {
+internal class DetailNavigatorImpl @Inject constructor() : DetailNavigator {
     override fun openDetail(context: Context, session: Session) {
         DetailActivity.start(context, session)
     }


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Hilt를 통한 의존성 주입을 사용하면서, 인터페이스를 이용하여 모듈간의 의존성을 공개합니다.
- 이에 따라 실제 구현체와 모듈은 외부에 노출될 이유가 없어 internal modifier로 선언합니다.